### PR TITLE
Matt develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -170,17 +170,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -258,15 +258,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -320,9 +320,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "h2"
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "itoa"
@@ -1096,11 +1096,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -1296,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1506,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags",
 ]
@@ -1641,9 +1641,9 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "0.38.35"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags",
  "errno",
@@ -1654,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1683,9 +1683,9 @@ checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.7"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1706,11 +1706,11 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1744,18 +1744,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -1914,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
  "nom",
  "unicode_categories",
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcfa89bea9500db4a0d038513d7a060566bfc51d46d1c014847049a45cce85e8"
+checksum = "93334716a037193fac19df402f8571269c84a00852f6a7066b5d2616dcd64d3e"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -1937,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06e2f2bd861719b1f3f0c7dbe1d80c30bf59e76cf019f07d9014ed7eefb8e08"
+checksum = "d4d8060b456358185f7d50c55d9b5066ad956956fddec42ee2e8567134a8936e"
 dependencies = [
  "atoi",
  "bigdecimal",
@@ -1978,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f998a9defdbd48ed005a89362bd40dd2117502f15294f61c8d47034107dbbdc"
+checksum = "cac0692bcc9de3b073e8d747391827297e075c7710ff6276d9f7a1f3d58c6657"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1991,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d100558134176a2629d46cec0c8891ba0be8910f7896abfdb75ef4ab6f4e7ce"
+checksum = "1804e8a7c7865599c9c79be146dc8a9fd8cc86935fa641d3ea58e5f0688abaa5"
 dependencies = [
  "dotenvy",
  "either",
@@ -2017,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cac0ab331b14cb3921c62156d913e4c15b74fb6ec0f3146bd4ef6e4fb3c12"
+checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
 dependencies = [
  "atoi",
  "base64",
@@ -2060,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9734dbce698c67ecf67c442f768a5e90a49b2a4d61a9f1d59f73874bd4cf0710"
+checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
 dependencies = [
  "atoi",
  "base64",
@@ -2100,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75b419c3c1b1697833dd927bdc4c6545a620bc1bbafabd44e1efbe9afcd337e"
+checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
 dependencies = [
  "atoi",
  "flume",
@@ -2348,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2359,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2378,9 +2378,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2503,15 +2503,15 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]

--- a/crates/db-access/src/lib.rs
+++ b/crates/db-access/src/lib.rs
@@ -1,5 +1,6 @@
-mod models;
+pub mod models;
 pub mod queries;
+pub mod volatility;
 
 use dotenv::dotenv;
 use sqlx::postgres::PgPool;

--- a/crates/db-access/src/main.rs
+++ b/crates/db-access/src/main.rs
@@ -1,21 +1,31 @@
-use db_access::{queries::get_block_by_number, DbConnection};
+use db_access::models::BlockHeaderSubset;
+use db_access::queries::get_base_fees_between_blocks;
+use db_access::volatility::calculate_volatility;
+use db_access::DbConnection;
 
 #[tokio::main]
 async fn main() -> Result<(), sqlx::Error> {
+    // Connect to DB
     let db = DbConnection::new().await?;
 
-    let block_number = 12345;
-    match get_block_by_number(&db.pool, block_number).await {
-        Ok(Some(block)) => {
-            println!("Block found: {:?}", block);
-        }
-        Ok(None) => {
-            println!("No block found with number: {}", block_number);
-        }
-        Err(e) => {
-            eprintln!("Failed to fetch block: {}", e);
-        }
-    }
+    // Volatlity
+
+    // Get block headers
+    let start_block = 13733852;
+    let end_block = start_block + 5;
+    let block_headers: Vec<BlockHeaderSubset> =
+        get_base_fees_between_blocks(&db.pool, start_block, end_block).await?;
+
+    // Calculate the volatility
+    let volatility = calculate_volatility(&block_headers).await;
+
+    println!(
+        "> VOL = {:.4}%, {} as u128",
+        volatility as f32 / 10_000.0,
+        volatility
+    );
+
+    // End Volatility
 
     Ok(())
 }

--- a/crates/db-access/src/queries.rs
+++ b/crates/db-access/src/queries.rs
@@ -137,15 +137,15 @@ pub async fn get_block_by_number(
     let block = sqlx::query_as!(
         BlockHeader,
         r#"
-        SELECT 
-            block_hash, 
-            number, 
-            gas_limit, 
-            gas_used, 
-            base_fee_per_gas, 
-            nonce, 
-            transaction_root, 
-            receipts_root, 
+        SELECT
+            block_hash,
+            number,
+            gas_limit,
+            gas_used,
+            base_fee_per_gas,
+            nonce,
+            transaction_root,
+            receipts_root,
             state_root
         FROM blockheaders
         WHERE number = $1

--- a/crates/db-access/src/volatility.rs
+++ b/crates/db-access/src/volatility.rs
@@ -1,14 +1,14 @@
 use crate::models::BlockHeaderSubset;
 
-fn hex_string_to_u128(hex_str: &String) -> u128 {
+fn hex_string_to_u128(hex_str: &String) -> f64 {
     // Remove the "0x" prefix if it exists
     let stripped = hex_str.trim_start_matches("0x");
 
-    // Return the hex string as a u128, panic if it fails
+    // Return the hex string as f64, panic if it fails
     if let Ok(value) = u128::from_str_radix(stripped, 16) {
-        return value;
+        return value as f64;
     } else {
-        panic!("Error converting hex string {:?} to u128", hex_str);
+        panic!("Error converting hex string {:?} to f64", hex_str);
     }
 }
 
@@ -20,22 +20,18 @@ pub async fn calculate_volatility(blocks: &[BlockHeaderSubset]) -> u128 {
         if let (Some(ref basefee_current), Some(ref basefee_previous)) =
             (&blocks[i].base_fee_per_gas, &blocks[i - 1].base_fee_per_gas)
         {
-            // Convert base fees from hex strings to u128s
-            let (basefee_current_wei, basefee_previous_wei) = (
-                hex_string_to_u128(&basefee_current),
-                hex_string_to_u128(&basefee_previous),
-            );
+            // Convert base fees from hex string to f64
+            let basefee_current = hex_string_to_u128(&basefee_current);
+            let basefee_previous = hex_string_to_u128(&basefee_previous);
 
             // If the previous base fee is zero, skip to the next iteration
-            if basefee_previous_wei == 0 {
+            if basefee_previous == 0.0 {
                 continue;
             }
 
             // Calculate log return and add it to the returns vector
-            let basefee_current_f64 = basefee_current_wei as f64;
-            let basefee_previous_f64 = basefee_previous_wei as f64;
 
-            returns.push((basefee_current_f64 / basefee_previous_f64).ln());
+            returns.push((basefee_current / basefee_previous).ln());
         }
     }
 

--- a/crates/db-access/src/volatility.rs
+++ b/crates/db-access/src/volatility.rs
@@ -1,0 +1,59 @@
+use crate::models::BlockHeaderSubset;
+
+fn hex_string_to_u128(hex_str: &String) -> u128 {
+    // Remove the "0x" prefix if it exists
+    let stripped = hex_str.trim_start_matches("0x");
+
+    // Return the hex string as a u128, panic if it fails
+    if let Ok(value) = u128::from_str_radix(stripped, 16) {
+        return value;
+    } else {
+        panic!("Error converting hex string {:?} to u128", hex_str);
+    }
+}
+
+// Returns volatility as BPS (i.e., 5001 means VOL=50.01%)
+pub async fn calculate_volatility(blocks: &[BlockHeaderSubset]) -> u128 {
+    // Calculate log returns
+    let mut returns: Vec<f64> = Vec::new();
+    for i in 1..blocks.len() {
+        if let (Some(ref basefee_current), Some(ref basefee_previous)) =
+            (&blocks[i].base_fee_per_gas, &blocks[i - 1].base_fee_per_gas)
+        {
+            // Convert base fees from hex strings to u128s
+            let (basefee_current_wei, basefee_previous_wei) = (
+                hex_string_to_u128(&basefee_current),
+                hex_string_to_u128(&basefee_previous),
+            );
+
+            // If the previous base fee is zero, skip to the next iteration
+            if basefee_previous_wei == 0 {
+                continue;
+            }
+
+            // Calculate log return and add it to the returns vector
+            let basefee_current_f64 = basefee_current_wei as f64;
+            let basefee_previous_f64 = basefee_previous_wei as f64;
+
+            returns.push((basefee_current_f64 / basefee_previous_f64).ln());
+        }
+    }
+
+    // If there are no returns the volatility is 0
+    if returns.is_empty() {
+        return 0;
+    }
+
+    // Calculate average returns
+    let mean_return: f64 = returns.iter().sum::<f64>() / returns.len() as f64;
+
+    // Calculate variance of average returns
+    let variance: f64 = returns
+        .iter()
+        .map(|&r| (r - mean_return).powi(2))
+        .sum::<f64>()
+        / returns.len() as f64;
+
+    // Square root the variance to get the volatility, translate to BPS (integer)
+    (variance.sqrt() * 10_000.0).round() as u128
+}

--- a/crates/db-access/src/volatility.rs
+++ b/crates/db-access/src/volatility.rs
@@ -30,7 +30,6 @@ pub async fn calculate_volatility(blocks: &[BlockHeaderSubset]) -> u128 {
             }
 
             // Calculate log return and add it to the returns vector
-
             returns.push((basefee_current / basefee_previous).ln());
         }
     }

--- a/crates/db-access/src/volatility.rs
+++ b/crates/db-access/src/volatility.rs
@@ -1,6 +1,6 @@
 use crate::models::BlockHeaderSubset;
 
-fn hex_string_to_u128(hex_str: &String) -> f64 {
+fn hex_string_to_f64(hex_str: &String) -> f64 {
     // Remove the "0x" prefix if it exists
     let stripped = hex_str.trim_start_matches("0x");
 
@@ -21,8 +21,8 @@ pub async fn calculate_volatility(blocks: &[BlockHeaderSubset]) -> u128 {
             (&blocks[i].base_fee_per_gas, &blocks[i - 1].base_fee_per_gas)
         {
             // Convert base fees from hex string to f64
-            let basefee_current = hex_string_to_u128(&basefee_current);
-            let basefee_previous = hex_string_to_u128(&basefee_previous);
+            let basefee_current = hex_string_to_f64(&basefee_current);
+            let basefee_previous = hex_string_to_f64(&basefee_previous);
 
             // If the previous base fee is zero, skip to the next iteration
             if basefee_previous == 0.0 {


### PR DESCRIPTION
Added logic for computing volatility of base fee. 

Repo Changes:
- Had to run `cargo update` to get the crate to build
- Made `models` module public in `crates/db-access/src/lib.rs`

Additional:
- Created `hex_string_to_f64(hex_str: &String)` helper to convert base fee data to usable form easily