### PR TITLE
chore: setup docker image for deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.env
+.vscode
+target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Multistage build
+FROM rust:1.81 AS builder
+
+WORKDIR /usr/app
+COPY . .
+RUN cargo build --release
+
+# Use a distroless docker image which should further reduce the size.
+# This one is setup specifically for rust.
+FROM gcr.io/distroless/cc-debian12
+WORKDIR /usr/app
+COPY --from=builder /usr/app/target/release/server .
+
+EXPOSE 3000
+CMD ["/usr/app/server"]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,3 +19,8 @@ starknet-crypto = "0.7.2"
 
 [dev-dependencies]
 axum-test = "15.7.1"
+
+
+[[bin]]
+name = "server"
+path = "src/main.rs"


### PR DESCRIPTION
Per title, setup docker image to later be used for deployment at ECS.

There's no github action setup with this, and as such we will need to add that before CD is possible.