### PR TITLE
feat: impl simple api key auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 **/.DS_Store
 .env
 .vscode
+data.csv

--- a/.sqlx/query-034885113955b2e663200231052c152570bba627d714ac33b3d7f59ce1c595b9.json
+++ b/.sqlx/query-034885113955b2e663200231052c152570bba627d714ac33b3d7f59ce1c595b9.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            key,\n            name\n        FROM api_keys\n        WHERE key = $1\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "key",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "034885113955b2e663200231052c152570bba627d714ac33b3d7f59ce1c595b9"
+}

--- a/.sqlx/query-0a911fbf7e5b0aa9f574f1a8a5e127b2250cb225ba82ea19f1068238447836db.json
+++ b/.sqlx/query-0a911fbf7e5b0aa9f574f1a8a5e127b2250cb225ba82ea19f1068238447836db.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO api_keys (key, name) VALUES ($1, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "0a911fbf7e5b0aa9f574f1a8a5e127b2250cb225ba82ea19f1068238447836db"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3641,6 +3641,9 @@ dependencies = [
  "starknet-crypto",
  "statrs",
  "tokio",
+ "tower",
+ "tower-http",
+ "uuid 1.10.0",
 ]
 
 [[package]]
@@ -4578,6 +4581,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 0.1.2",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.6.0",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "mime",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,6 +1828,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,6 +2079,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,6 +2271,12 @@ dependencies = [
  "rand_distr 0.2.2",
  "rand_pcg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
@@ -3124,8 +3149,17 @@ checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3136,8 +3170,14 @@ checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3643,6 +3683,8 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "uuid 1.10.0",
 ]
 
@@ -3676,6 +3718,15 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest",
  "keccak",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -4415,6 +4466,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4646,6 +4707,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4785,6 +4876,12 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom 0.2.15",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/crates/db-access/migrations/20241004065744_api_key_auth.down.sql
+++ b/crates/db-access/migrations/20241004065744_api_key_auth.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+DROP TABLE api_keys;

--- a/crates/db-access/migrations/20241004065744_api_key_auth.up.sql
+++ b/crates/db-access/migrations/20241004065744_api_key_auth.up.sql
@@ -1,0 +1,7 @@
+-- Add up migration script here
+CREATE TABLE api_keys (
+    id SERIAL PRIMARY KEY,
+    key TEXT NOT NULL UNIQUE,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/crates/db-access/src/auth.rs
+++ b/crates/db-access/src/auth.rs
@@ -1,0 +1,32 @@
+use crate::models::ApiKey;
+use sqlx::{Error, PgPool};
+
+pub async fn add_api_key(pool: &PgPool, key: String, name: String) -> Result<(), Error> {
+    sqlx::query!(
+        r#"INSERT INTO api_keys (key, name) VALUES ($1, $2)"#,
+        key,
+        name
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn find_api_key(pool: &PgPool, key: String) -> Result<ApiKey, Error> {
+    let result = sqlx::query_as!(
+        ApiKey,
+        r#"
+        SELECT
+            key,
+            name
+        FROM api_keys
+        WHERE key = $1
+    "#,
+        key
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(result)
+}

--- a/crates/db-access/src/lib.rs
+++ b/crates/db-access/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod models;
 pub mod queries;
 

--- a/crates/db-access/src/models.rs
+++ b/crates/db-access/src/models.rs
@@ -33,3 +33,9 @@ pub struct BlockHeaderSubset {
     pub base_fee_per_gas: Option<String>,
     pub timestamp: Option<i64>,
 }
+
+#[derive(sqlx::FromRow, Debug)]
+pub struct ApiKey {
+    pub key: String,
+    pub name: Option<String>,
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -11,7 +11,7 @@ tokio = { version = "1", features = ["full"] }
 axum = "0.7.7"
 axum-extra = { version = "0.9.4", features = ["json-deserializer"] }
 tower = "0.5.1"
-tower-http = {version="0.6.1", features = ["cors", "trace", "auth"]}
+tower-http = { version = "0.6.1", features = ["cors", "trace", "auth"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0.89"
@@ -19,6 +19,12 @@ chrono = "0.4.38"
 reqwest = { version = "0.12", features = ["json"] }
 starknet = "0.12.0"
 starknet-crypto = "0.7.2"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = [
+    "registry",
+    "env-filter",
+    "fmt",
+] }
 
 sqlx = { version = "0.8.0", features = [
     "postgres",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 db-access = { path = "../db-access" }
 tokio = { version = "1", features = ["full"] }
 axum = "0.7.7"
-axum-extra = { version = "0.9.4", features = [
-    "json-deserializer",
-] }
+axum-extra = { version = "0.9.4", features = ["json-deserializer"] }
+tower = "0.5.1"
+tower-http = {version="0.6.1", features = ["cors", "trace", "auth"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0.89"
@@ -20,14 +20,23 @@ reqwest = { version = "0.12", features = ["json"] }
 starknet = "0.12.0"
 starknet-crypto = "0.7.2"
 
-sqlx = { version = "0.8.0", features = ["postgres", "runtime-tokio-native-tls", "bigdecimal"] }
+sqlx = { version = "0.8.0", features = [
+    "postgres",
+    "runtime-tokio-native-tls",
+    "bigdecimal",
+] }
 
 # Reserve price dependencies
 linfa = "0.7.0"
 linfa-linear = "0.7.0"
 ndarray = "0.15"
 ndarray-linalg = { version = "0.16", features = ["openblas-system"] }
-polars = { version = "0.41.3", features = ["lazy", "dynamic_group_by", "rolling_window", "ndarray"] }
+polars = { version = "0.41.3", features = [
+    "lazy",
+    "dynamic_group_by",
+    "rolling_window",
+    "ndarray",
+] }
 polars-core = "0.41.3"
 polars-io = "0.41.3"
 statrs = "0.16"
@@ -35,6 +44,7 @@ optimization = "0.2.0"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 ndarray-rand = "0.15.0"
+uuid = { version = "1.10.0", features = ["v4"] }
 
 [dev-dependencies]
 axum-test = "15.7.1"
@@ -43,3 +53,7 @@ axum-test = "15.7.1"
 [[bin]]
 name = "server"
 path = "src/main.rs"
+
+[[bin]]
+name = "create_api_key"
+path = "src/scripts/create_api_key.rs"

--- a/crates/server/src/handlers/pricing_callback.rs
+++ b/crates/server/src/handlers/pricing_callback.rs
@@ -6,7 +6,7 @@ use super::get_pricing_data::PitchLakeJobCallback;
 pub async fn pricing_callback(
     Json(payload): Json<PitchLakeJobCallback>,
 ) -> (StatusCode, &'static str) {
-    println!("Payload received! {:?}", payload);
+    tracing::debug!("Payload received! {:?}", payload);
 
     (StatusCode::OK, "Callback OK!")
 }

--- a/crates/server/src/handlers/pricing_callback.rs
+++ b/crates/server/src/handlers/pricing_callback.rs
@@ -10,3 +10,5 @@ pub async fn pricing_callback(
 
     (StatusCode::OK, "Callback OK!")
 }
+
+// No test needed here, since we only use this for internal testing purposes. Due for removal.

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod handlers;
+pub mod middlewares;
 pub mod pricing_data;

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,20 +1,29 @@
 use anyhow::Result;
 use axum::{
+    middleware::from_fn_with_state,
     routing::{get, post},
     Router,
 };
 use db_access::DbConnection;
-use server::handlers;
+use server::{handlers, middlewares::auth::simple_apikey_auth};
+use tower::ServiceBuilder;
+use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let db = DbConnection::new().await?;
 
     let app = Router::new()
+        .layer(
+            ServiceBuilder::new()
+                .layer(TraceLayer::new_for_http())
+                .layer(CorsLayer::permissive()),
+        )
         .route("/", get(handlers::root::root))
         .route(
             "/pricing_data",
-            post(handlers::get_pricing_data::get_pricing_data),
+            post(handlers::get_pricing_data::get_pricing_data)
+                .layer(from_fn_with_state(db.clone(), simple_apikey_auth)),
         )
         .route(
             "/callback_test",

--- a/crates/server/src/middlewares/auth.rs
+++ b/crates/server/src/middlewares/auth.rs
@@ -32,7 +32,7 @@ pub async fn simple_apikey_auth(
             return match matching_api_key {
                 Ok(_) => next.run(request).await,
                 Err(err) => {
-                    eprintln!("{:?}", err);
+                    tracing::debug!("{:?}", err);
                     (StatusCode::UNAUTHORIZED, Json(response_data)).into_response()
                 }
             };

--- a/crates/server/src/middlewares/auth.rs
+++ b/crates/server/src/middlewares/auth.rs
@@ -1,0 +1,43 @@
+use axum::{
+    extract::{Request, State},
+    http::{HeaderMap, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use db_access::{auth::find_api_key, DbConnection};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct AuthErrorResponse {
+    error: String,
+}
+
+/// A simple api key auth that checks if the key provided is in the db
+/// TODO: change this to use the more comprehensive tower_http auth middleware.
+pub async fn simple_apikey_auth(
+    State(db): State<DbConnection>,
+    headers: HeaderMap,
+    request: Request,
+    next: Next,
+) -> Response {
+    let response_data = AuthErrorResponse {
+        error: "Unauthenticated".to_string(),
+    };
+
+    if let Some(incoming_api_key) = headers.get("x-api-key") {
+        if let Ok(incoming_api_key) = incoming_api_key.to_str() {
+            let matching_api_key = find_api_key(&db.pool, incoming_api_key.to_string()).await;
+
+            return match matching_api_key {
+                Ok(_) => next.run(request).await,
+                Err(err) => {
+                    eprintln!("{:?}", err);
+                    (StatusCode::UNAUTHORIZED, Json(response_data)).into_response()
+                }
+            };
+        }
+    }
+
+    (StatusCode::UNAUTHORIZED, Json(response_data)).into_response()
+}

--- a/crates/server/src/middlewares/mod.rs
+++ b/crates/server/src/middlewares/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/crates/server/src/pricing_data/utils.rs
+++ b/crates/server/src/pricing_data/utils.rs
@@ -9,3 +9,35 @@ pub fn hex_string_to_f64(hex_str: &String) -> f64 {
         panic!("Error converting hex string {:?} to f64", hex_str);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hex_string_to_f64_zero_value() {
+        let result = hex_string_to_f64(&"0x0".to_string());
+
+        assert_eq!(result, 0f64);
+    }
+
+    #[test]
+    fn test_hex_string_to_f64_prefixed_value() {
+        let result = hex_string_to_f64(&"0x12345".to_string());
+
+        assert_eq!(result, 74565_f64);
+    }
+
+    #[test]
+    fn test_hex_string_to_f64_non_prefixed_value() {
+        let result = hex_string_to_f64(&"12345".to_string());
+
+        assert_eq!(result, 74565_f64);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_hex_string_to_f64_invalid_value() {
+        hex_string_to_f64(&"shouldpanic".to_string());
+    }
+}

--- a/crates/server/src/scripts/create_api_key.rs
+++ b/crates/server/src/scripts/create_api_key.rs
@@ -1,0 +1,22 @@
+use std::env;
+
+use db_access::{auth::add_api_key, DbConnection};
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> Result<(), sqlx::Error> {
+    let db = DbConnection::new().await?;
+
+    let name = env::args()
+        .nth(1)
+        .expect("Give a name or tag to your api key");
+
+    // Generate a new API key (using UUID v4 for this example)
+    let api_key = Uuid::new_v4().to_string();
+
+    add_api_key(&db.pool, api_key.clone(), name).await?;
+
+    println!("API Key: {}", api_key);
+
+    Ok(())
+}


### PR DESCRIPTION
Simple api key authentication is added via this PR.  Now only authenticated request may call the pricing APIs. Does not allow auto creation of api keys by third party but requires users with read access to create it for them. In the future this should be expanded and added to in order to allow users to create their own keys.

Additionally also included a script to create an api keys.