### PR TITLE
fix: incorrect twap calculation

### DIFF
--- a/crates/server/src/handlers/get_pricing_data.rs
+++ b/crates/server/src/handlers/get_pricing_data.rs
@@ -2,7 +2,6 @@ use axum::{extract::State, http::StatusCode, Json};
 use db_access::{queries::get_block_headers_by_time_range, DbConnection};
 use serde::{Deserialize, Serialize};
 use starknet_crypto::{poseidon_hash_single, Felt};
-use std::collections::HashMap;
 use tokio::{join, time::Instant};
 
 use crate::pricing_data::{
@@ -39,7 +38,7 @@ pub enum PitchLakeJobCallback {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PitchLakeJobSuccessCallback {
     pub job_id: String,
-    pub twap: HashMap<String, f64>,
+    pub twap: f64,
     pub volatility: f64,
     pub reserve_price: f64,
 }

--- a/crates/server/src/pricing_data/twap.rs
+++ b/crates/server/src/pricing_data/twap.rs
@@ -1,59 +1,30 @@
-use anyhow::Error;
-use chrono::prelude::*;
+use anyhow::{anyhow, Error};
 use db_access::models::BlockHeader;
-use std::collections::HashMap;
 
 use super::utils::hex_string_to_f64;
 
-#[derive(Debug, Clone)]
-pub struct AggregatedBaseFee {
-    pub base_fee_mean: f64,
-    pub number: f64,
-}
-
 /// Calculates the time weighted average price (TWAP) of the base fee.
 /// TODO: handle the unwraps properly, or at least propagate them upwards.
-pub async fn calculate_twap(headers: Vec<BlockHeader>) -> Result<HashMap<String, f64>, Error> {
-    let mut hourly_fee_data_mapping: HashMap<String, AggregatedBaseFee> = HashMap::new();
-
-    headers.iter().for_each(|header| {
-        let new_date = DateTime::<Utc>::from_timestamp(header.timestamp.unwrap(), 0).unwrap();
-        let new_date_str = format!(
-            "{}-{}-{} {}:00:00",
-            new_date.year(),
-            new_date.month(),
-            new_date.day(),
-            new_date.hour(),
-        );
-
-        if hourly_fee_data_mapping.contains_key(new_date_str.as_str()) {
-            let current_data = hourly_fee_data_mapping
-                .get_mut(new_date_str.as_str())
-                .unwrap();
-            current_data.base_fee_mean +=
-                hex_string_to_f64(&header.base_fee_per_gas.clone().unwrap());
-        } else {
-            hourly_fee_data_mapping.insert(
-                new_date_str.clone(),
-                AggregatedBaseFee {
-                    base_fee_mean: hex_string_to_f64(&header.base_fee_per_gas.clone().unwrap()),
-                    number: 1f64,
-                },
-            );
-        }
-    });
-
-    let hourly_fee_data_vec: Vec<(String, f64)> = hourly_fee_data_mapping
+pub async fn calculate_twap(headers: Vec<BlockHeader>) -> Result<f64, Error> {
+    let total_base_fee = headers
         .iter()
-        .map(|(date, data)| (date.clone(), data.base_fee_mean / data.number))
-        .collect();
+        .map(|header| {
+            let base_fee = match header.base_fee_per_gas.clone() {
+                Some(val) => val,
+                None => "0x0".to_string(),
+            };
+            hex_string_to_f64(&base_fee)
+        })
+        .reduce(|prev, current| prev + current);
 
-    // Calculate the twap with a sliding window of 7 days.
-    let mut twap_7d_mapping: HashMap<String, f64> = HashMap::new();
-    hourly_fee_data_vec[..].windows(24 * 7).for_each(|window| {
-        let twap_7d = window.iter().map(|(_, data)| data).sum::<f64>() / window.len() as f64;
-        twap_7d_mapping.insert(window.first().unwrap().0.clone(), twap_7d);
-    });
+    let total_base_fee = match total_base_fee {
+        Some(val) => val,
+        None => return Err(anyhow!("Failed during calculation of twap.")),
+    };
 
-    Ok(twap_7d_mapping)
+    // Calculate the twap, which in this case we are assuming to have the window of 30days
+    // according to the given timestamp range.
+    let twap_result = total_base_fee / headers.len() as f64;
+
+    Ok(twap_result)
 }


### PR DESCRIPTION
Correct the twap calculation, to instead calculate for the range given via the timestamp instead of forcing it to conform to 7 days. This should make the twap value returned a single value instead of being a table of values.