### PR TITLE
feat: add health check endpoint

### DIFF
--- a/crates/server/src/handlers/health_check.rs
+++ b/crates/server/src/handlers/health_check.rs
@@ -1,4 +1,6 @@
-pub async fn root() -> &'static str {
+pub async fn health_check() -> &'static str {
+    // TODO: should actually also check db connection and more
+    // right now its essentially a liveness check.
     "OK"
 }
 
@@ -11,7 +13,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_root() {
-        let app = Router::new().route("/", get(root));
+        let app = Router::new().route("/", get(health_check));
         let server = TestServer::new(app).unwrap();
 
         let response = server.get("/").await;

--- a/crates/server/src/handlers/mod.rs
+++ b/crates/server/src/handlers/mod.rs
@@ -1,3 +1,3 @@
 pub mod get_pricing_data;
+pub mod health_check;
 pub mod job_status;
-pub mod root;


### PR DESCRIPTION
Change the root endpoint to a simple health check ping endpoint.

In the future actual checks should be performed within the function.