### PR TITLE
chore: unify job status responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,6 +2162,7 @@ dependencies = [
  "eth-rlp-verify",
  "eyre",
  "reqwest 0.11.27",
+ "serde",
  "serde_json",
  "sqlx 0.7.4",
  "tokio",

--- a/crates/db-access/Cargo.toml
+++ b/crates/db-access/Cargo.toml
@@ -14,5 +14,6 @@ tracing = { workspace = true }
 
 chrono = "0.4.38"
 reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 eth-rlp-verify = { git = "https://github.com/ametel01/eth-rlp-verify.git" }

--- a/crates/db-access/src/models.rs
+++ b/crates/db-access/src/models.rs
@@ -1,4 +1,5 @@
 use eth_rlp_verify::block_header::BlockHeader as EthBlockHeader;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(sqlx::FromRow, Debug)]
@@ -43,7 +44,7 @@ pub struct ApiKey {
     pub name: Option<String>,
 }
 
-#[derive(sqlx::Type, Debug, PartialEq)]
+#[derive(sqlx::Type, Debug, PartialEq, Serialize, Deserialize)]
 #[sqlx(type_name = "TEXT")]
 pub enum JobStatus {
     Pending,

--- a/crates/server/src/handlers/fixtures/mod.rs
+++ b/crates/server/src/handlers/fixtures/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    types::{JobResponse, PitchLakeJobRequest},
+    types::{GetJobStatusResponseEnum, JobResponse, PitchLakeJobRequest},
     AppState,
 };
 use axum::{extract::State, Json};
@@ -63,7 +63,10 @@ impl TestContext {
             .expect("Failed to create job request");
     }
 
-    pub async fn get_job_status(&self, job_id: &str) -> (StatusCode, Json<serde_json::Value>) {
+    pub async fn get_job_status(
+        &self,
+        job_id: &str,
+    ) -> (StatusCode, Json<GetJobStatusResponseEnum>) {
         get_job_status(
             State(self.app_state.clone()),
             axum::extract::Path(job_id.to_string()),

--- a/crates/server/src/handlers/get_pricing_data.rs
+++ b/crates/server/src/handlers/get_pricing_data.rs
@@ -31,8 +31,8 @@ pub async fn get_pricing_data(
             StatusCode::BAD_REQUEST,
             Json(JobResponse {
                 job_id: String::new(),
-                message: "Identifiers cannot be empty.".to_string(),
-                status_url: String::new(),
+                message: Some("Identifiers cannot be empty.".to_string()),
+                status: None,
             }),
         );
     }
@@ -52,18 +52,22 @@ pub async fn get_pricing_data(
                 StatusCode::CONFLICT,
                 Json(JobResponse {
                     job_id: job_id.clone(),
-                    message: "Job is already pending. Use the status endpoint to monitor progress."
-                        .to_string(),
-                    status_url: format!("/job_status/{}", job_id),
+                    message: Some(
+                        "Job is already pending. Use the status endpoint to monitor progress."
+                            .to_string(),
+                    ),
+                    status: Some(JobStatus::Pending),
                 }),
             ),
             JobStatus::Completed => (
                 StatusCode::CONFLICT,
                 Json(JobResponse {
                     job_id: job_id.clone(),
-                    message: "Job has already been completed. No further processing required."
-                        .to_string(),
-                    status_url: format!("/job_status/{}", job_id),
+                    message: Some(
+                        "Job has already been completed. No further processing required."
+                            .to_string(),
+                    ),
+                    status: Some(JobStatus::Completed),
                 }),
             ),
             JobStatus::Failed => {
@@ -72,8 +76,8 @@ pub async fn get_pricing_data(
                 {
                     return (StatusCode::INTERNAL_SERVER_ERROR, Json(JobResponse {
                         job_id: job_id.clone(),
-                        message: format!("Previous job request failed. An error occurred while updating job status: {}", e).to_string(),
-                        status_url: format!("/job_status/{}", job_id),
+                        message: Some(format!("Previous job request failed. An error occurred while updating job status: {}", e).to_string()),
+                        status: Some(JobStatus::Failed)
                     }));
                 }
                 tokio::spawn(process_job(state.db.clone(), job_id.clone(), payload));
@@ -82,8 +86,10 @@ pub async fn get_pricing_data(
                     StatusCode::OK,
                     Json(JobResponse {
                         job_id: job_id.clone(),
-                        message: "Previous job request failed. Reprocessing initiated.".to_string(),
-                        status_url: format!("/job_status/{}", job_id),
+                        message: Some(
+                            "Previous job request failed. Reprocessing initiated.".to_string(),
+                        ),
+                        status: Some(JobStatus::Pending),
                     }),
                 )
             }
@@ -98,9 +104,10 @@ pub async fn get_pricing_data(
                         StatusCode::CREATED,
                         Json(JobResponse {
                             job_id: job_id.clone(),
-                            message: "New job request registered and processing initiated."
-                                .to_string(),
-                            status_url: format!("/job_status/{}", job_id),
+                            message: Some(
+                                "New job request registered and processing initiated.".to_string(),
+                            ),
+                            status: Some(JobStatus::Pending),
                         }),
                     )
                 }
@@ -110,8 +117,11 @@ pub async fn get_pricing_data(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         Json(JobResponse {
                             job_id: job_id.clone(),
-                            message: format!("An error occurred while creating the job: {}", e),
-                            status_url: format!("/job_status/{}", job_id),
+                            message: Some(format!(
+                                "An error occurred while creating the job: {}",
+                                e
+                            )),
+                            status: Some(JobStatus::Failed),
                         }),
                     )
                 }
@@ -123,8 +133,11 @@ pub async fn get_pricing_data(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(JobResponse {
                     job_id: job_id.clone(),
-                    message: format!("An error occurred while processing the request: {}", e),
-                    status_url: format!("/job_status/{}", job_id),
+                    message: Some(format!(
+                        "An error occurred while processing the request: {}",
+                        e
+                    )),
+                    status: Some(JobStatus::Failed),
                 }),
             )
         }
@@ -210,8 +223,8 @@ fn validate_time_ranges(
                 StatusCode::BAD_REQUEST,
                 JobResponse {
                     job_id: String::new(),
-                    message: format!("Invalid time range for {} calculation.", name),
-                    status_url: String::new(),
+                    message: Some(format!("Invalid time range for {} calculation.", name)),
+                    status: None,
                 },
             ));
         }
@@ -224,7 +237,7 @@ fn validate_time_ranges(
 mod tests {
     use super::*;
     use crate::handlers::fixtures::TestContext;
-    use crate::types::{PitchLakeJobRequest, PitchLakeJobRequestParams};
+    use crate::types::{GetJobStatusResponseEnum, PitchLakeJobRequest, PitchLakeJobRequestParams};
     use axum::http::StatusCode;
 
     #[tokio::test]
@@ -245,10 +258,10 @@ mod tests {
         assert_eq!(status, StatusCode::CREATED);
         assert!(!response.job_id.is_empty());
         assert_eq!(
-            response.message,
+            response.message.unwrap(),
             "New job request registered and processing initiated."
         );
-        assert!(response.status_url.starts_with("/job_status/"));
+        assert_eq!(response.status.unwrap(), JobStatus::Pending);
     }
 
     #[tokio::test]
@@ -273,10 +286,10 @@ mod tests {
         assert_eq!(status, StatusCode::CONFLICT);
         assert_eq!(response.job_id, job_id);
         assert_eq!(
-            response.message,
+            response.message.unwrap(),
             "Job is already pending. Use the status endpoint to monitor progress."
         );
-        assert_eq!(response.status_url, format!("/job_status/{}", job_id));
+        assert_eq!(response.status.unwrap(), JobStatus::Pending);
     }
 
     #[tokio::test]
@@ -301,10 +314,10 @@ mod tests {
         assert_eq!(status, StatusCode::CONFLICT);
         assert_eq!(response.job_id, job_id);
         assert_eq!(
-            response.message,
+            response.message.unwrap(),
             "Job has already been completed. No further processing required."
         );
-        assert_eq!(response.status_url, format!("/job_status/{}", job_id));
+        assert_eq!(response.status.unwrap(), JobStatus::Completed)
     }
 
     #[tokio::test]
@@ -329,14 +342,20 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(response.job_id, job_id);
         assert_eq!(
-            response.message,
+            response.message.unwrap(),
             "Previous job request failed. Reprocessing initiated."
         );
-        assert_eq!(response.status_url, format!("/job_status/{}", job_id));
+        assert_eq!(response.status.unwrap(), JobStatus::Pending);
 
         // Verify that the job status was updated to Pending
         let (_, Json(status_response)) = ctx.get_job_status(&job_id).await;
-        assert_eq!(status_response["status"], "Pending");
+
+        let status_response = match status_response {
+            GetJobStatusResponseEnum::Success(success_res) => success_res,
+            GetJobStatusResponseEnum::Error(_) => panic!("Unexpected response status"),
+        };
+
+        assert_eq!(status_response.status.unwrap(), JobStatus::Pending);
     }
 
     #[tokio::test]
@@ -357,10 +376,10 @@ mod tests {
         assert_eq!(status, StatusCode::CREATED);
         assert!(!response.job_id.is_empty());
         assert_eq!(
-            response.message,
+            response.message.unwrap(),
             "New job request registered and processing initiated."
         );
-        assert!(response.status_url.starts_with("/job_status/"));
+        assert_eq!(response.status.unwrap(), JobStatus::Pending);
 
         // Verify that the job_id is a hash of all identifiers
         let expected_job_id =
@@ -384,9 +403,9 @@ mod tests {
         let (status, Json(response)) = ctx.get_pricing_data(payload).await;
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert_eq!(response.message, "Identifiers cannot be empty.");
+        assert_eq!(response.message.unwrap(), "Identifiers cannot be empty.");
         assert!(response.job_id.is_empty());
-        assert!(response.status_url.is_empty());
+        assert_eq!(response.status, None)
     }
 
     #[tokio::test]
@@ -405,8 +424,11 @@ mod tests {
         let (status, Json(response)) = ctx.get_pricing_data(payload).await;
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert_eq!(response.message, "Invalid time range for TWAP calculation.");
+        assert_eq!(
+            response.message.unwrap(),
+            "Invalid time range for TWAP calculation."
+        );
         assert!(response.job_id.is_empty());
-        assert!(response.status_url.is_empty());
+        assert_eq!(response.status, None)
     }
 }

--- a/crates/server/src/handlers/job_status.rs
+++ b/crates/server/src/handlers/job_status.rs
@@ -1,35 +1,36 @@
+use crate::types::{ErrorResponse, GetJobStatusResponseEnum, JobResponse};
 use crate::AppState;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
 use db_access::queries::get_job_request;
-use serde_json::json;
 
 #[axum::debug_handler]
 pub async fn get_job_status(
     State(state): State<AppState>, // Use AppState as the state
     axum::extract::Path(job_id): axum::extract::Path<String>,
-) -> (StatusCode, Json<serde_json::Value>) {
+) -> (StatusCode, Json<GetJobStatusResponseEnum>) {
     match get_job_request(&state.db.pool, &job_id).await {
         Ok(Some(job)) => (
             StatusCode::OK,
-            Json(json!({
-                "job_id": job.job_id,
-                "status": job.status.to_string(),
+            Json(GetJobStatusResponseEnum::Success(JobResponse {
+                job_id: job.job_id,
+                message: None,
+                status: Some(job.status),
             })),
         ),
         Ok(None) => (
             StatusCode::NOT_FOUND,
-            Json(json!({
-                "error": "Job not found".to_string(),
+            Json(GetJobStatusResponseEnum::Error(ErrorResponse {
+                error: "Job not found".to_string(),
             })),
         ),
         Err(e) => {
             tracing::error!("Failed to get job status: {:?}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "error": "An internal error occurred. Please try again later.".to_string(),
+                Json(GetJobStatusResponseEnum::Error(ErrorResponse {
+                    error: "An internal error occurred. Please try again later.".to_string(),
                 })),
             )
         }
@@ -38,6 +39,8 @@ pub async fn get_job_status(
 
 #[cfg(test)]
 mod tests {
+    use core::panic;
+
     use crate::handlers::fixtures::TestContext;
 
     use super::*;
@@ -51,8 +54,13 @@ mod tests {
 
         let (status, Json(response)) = ctx.get_job_status(job_id).await;
 
+        let response = match response {
+            GetJobStatusResponseEnum::Error(err_response) => err_response,
+            GetJobStatusResponseEnum::Success(_) => panic!("Unexpected response status"),
+        };
+
         assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(response["error"], "Job not found");
+        assert_eq!(response.error, "Job not found");
     }
 
     #[tokio::test]
@@ -64,9 +72,14 @@ mod tests {
 
         let (status, Json(response)) = ctx.get_job_status(job_id).await;
 
+        let response = match response {
+            GetJobStatusResponseEnum::Success(success_res) => success_res,
+            GetJobStatusResponseEnum::Error(_) => panic!("Unexpected response status"),
+        };
+
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(response["job_id"], job_id);
-        assert_eq!(response["status"], "Pending");
+        assert_eq!(response.job_id, job_id);
+        assert_eq!(response.status.unwrap(), JobStatus::Pending);
     }
 
     #[tokio::test]
@@ -78,9 +91,14 @@ mod tests {
 
         let (status, Json(response)) = ctx.get_job_status(job_id).await;
 
+        let response = match response {
+            GetJobStatusResponseEnum::Success(success_res) => success_res,
+            GetJobStatusResponseEnum::Error(_) => panic!("Unexpected response status"),
+        };
+
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(response["job_id"], job_id);
-        assert_eq!(response["status"], "Failed");
+        assert_eq!(response.job_id, job_id);
+        assert_eq!(response.status.unwrap(), JobStatus::Failed);
     }
 
     #[tokio::test]
@@ -92,8 +110,13 @@ mod tests {
 
         let (status, Json(response)) = ctx.get_job_status(job_id).await;
 
+        let response = match response {
+            GetJobStatusResponseEnum::Success(success_res) => success_res,
+            GetJobStatusResponseEnum::Error(_) => panic!("Unexpected response status"),
+        };
+
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(response["job_id"], job_id);
-        assert_eq!(response["status"], "Completed");
+        assert_eq!(response.job_id, job_id);
+        assert_eq!(response.status.unwrap(), JobStatus::Completed);
     }
 }

--- a/crates/server/src/middlewares/auth.rs
+++ b/crates/server/src/middlewares/auth.rs
@@ -1,4 +1,4 @@
-use crate::{types::AuthErrorResponse, AppState};
+use crate::{types::ErrorResponse, AppState};
 use axum::{
     extract::State,
     http::{HeaderMap, Request, StatusCode},
@@ -16,7 +16,7 @@ pub async fn simple_apikey_auth(
     request: Request<axum::body::Body>,
     next: Next,
 ) -> Result<Response, StatusCode> {
-    let response_data = AuthErrorResponse {
+    let response_data = ErrorResponse {
         error: "Unauthenticated".to_string(),
     };
 

--- a/crates/server/src/types.rs
+++ b/crates/server/src/types.rs
@@ -1,3 +1,4 @@
+use db_access::models::JobStatus;
 use serde::{Deserialize, Serialize};
 
 // timestamp ranges for each sub-job calculation
@@ -17,22 +18,18 @@ pub struct PitchLakeJobRequest {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct JobResponse {
     pub job_id: String,
-    pub message: String,
-    pub status_url: String,
+    pub message: Option<String>,
+    pub status: Option<JobStatus>,
 }
 
-#[derive(Serialize)]
-pub struct JobStatusResponse {
-    pub job_id: String,
-    pub status: String,
-}
-
-#[derive(Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorResponse {
     pub error: String,
 }
 
-#[derive(Debug, Serialize)]
-pub struct AuthErrorResponse {
-    pub error: String,
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum GetJobStatusResponseEnum {
+    Success(JobResponse),
+    Error(ErrorResponse),
 }


### PR DESCRIPTION
Per title, and per last comment on PR here https://github.com/OilerNetwork/fossil-offchain-processor/pull/31#discussion_r1804337039.

This unifies the job response and the job status response to be the same, and remove any additional redundancies.