### PR TITLE
fix: slow req time during heavy processing

### DIFF
--- a/crates/server/src/handlers/get_pricing_data.rs
+++ b/crates/server/src/handlers/get_pricing_data.rs
@@ -9,7 +9,7 @@ use db_access::{
     DbConnection,
 };
 use starknet_crypto::{poseidon_hash_single, Felt};
-use tokio::{join, time::Instant};
+use tokio::{join, runtime::Handle, time::Instant};
 
 use crate::types::{JobResponse, PitchLakeJobRequest};
 use crate::{
@@ -76,7 +76,14 @@ pub async fn get_pricing_data(
                         status_url: format!("/job_status/{}", job_id),
                     }));
                 }
-                tokio::spawn(process_job(state.db.clone(), job_id.clone(), payload));
+
+                let db_clone = state.db.clone();
+                let job_id_clone = job_id.clone();
+                let handle = Handle::current();
+
+                tokio::task::spawn_blocking(move || {
+                    handle.block_on(process_job(db_clone, job_id_clone, payload));
+                });
 
                 (
                     StatusCode::OK,
@@ -92,7 +99,13 @@ pub async fn get_pricing_data(
             // New job
             match create_job_request(&state.db.pool, &job_id, JobStatus::Pending).await {
                 Ok(_) => {
-                    tokio::spawn(process_job(state.db.clone(), job_id.clone(), payload));
+                    let db_clone = state.db.clone();
+                    let job_id_clone = job_id.clone();
+                    let handle = Handle::current();
+
+                    tokio::task::spawn_blocking(move || {
+                        handle.block_on(process_job(db_clone, job_id_clone, payload));
+                    });
 
                     (
                         StatusCode::CREATED,


### PR DESCRIPTION
This PR attempts to resolve the slow req time during heavy processing by essentially treating the processing code as blocking, and then putting it into a 'blocking' thread which separates the task from the main thread thus reducing the load of the main thread running the api server.