### PR TITLE
API Readme & Docker compose update

### DIFF
--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -20,6 +20,10 @@ You can run the whole of the api server locally by using docker compose. This wi
 2. The migration service which will terminate once migration is completed
 3. The service itself
 
+First, you'll need to set the environment variables in the `.env` file. Create a copy of `.env.example` (root) into the `crates/server` directory, name it `.env` and fill in the values.
+
+Now you can run the components with:
+
 ```bash
 docker compose -f ./crates/server/docker-compose.yml up
 ```

--- a/crates/server/docker-compose.yml
+++ b/crates/server/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
+      - DATABASE_URL=${DATABASE_URL}
       - STARKNET_RPC_URL=${STARKNET_RPC_URL}
       - STARKNET_ACCOUNT_ADDRESS=${STARKNET_ACCOUNT_ADDRESS}
       - STARKNET_PRIVATE_KEY=${STARKNET_PRIVATE_KEY}


### PR DESCRIPTION
Changes
- Docker compose now reads the DB_URL from .env instead of using a hardcoded value. This helps using the deployed db with no risk of committing its connection URL by mistake.
- Updated the API's README indicating that a `.env` file needs to be created in the server crate's root directory