### PR TITLE
Add endpoint to return the latest block in the db

### DIFF
--- a/.sqlx/query-757f878e1eb404411c1b32592cdf2f1c0c885c6457357fd98f5525e656ff4ad8.json
+++ b/.sqlx/query-757f878e1eb404411c1b32592cdf2f1c0c885c6457357fd98f5525e656ff4ad8.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT number \n        FROM blockheaders \n        ORDER BY number DESC \n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "number",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "757f878e1eb404411c1b32592cdf2f1c0c885c6457357fd98f5525e656ff4ad8"
+}

--- a/crates/db-access/src/queries.rs
+++ b/crates/db-access/src/queries.rs
@@ -330,3 +330,19 @@ pub async fn update_job_result(
 
     Ok(())
 }
+
+pub async fn latest_block_number(pool: &PgPool) -> Result<Option<BlockHeaderSubset>, Error> {
+    let block = sqlx::query_as!(
+        BlockHeaderSubset,
+        r#"
+        SELECT number, timestamp, base_fee_per_gas
+        FROM blockheaders 
+        ORDER BY number DESC 
+        LIMIT 1
+        "#
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(block)
+}

--- a/crates/server/src/handlers/latest_block.rs
+++ b/crates/server/src/handlers/latest_block.rs
@@ -1,0 +1,132 @@
+use crate::types::{ErrorResponse, GetLatestBlockResponseEnum, LatestBlockResponse};
+use crate::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use db_access::queries::latest_block_number;
+
+#[axum::debug_handler]
+pub async fn get_latest_block_number(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<GetLatestBlockResponseEnum>) {
+    tracing::info!("Getting the latest block number");
+
+    match latest_block_number(&state.db.pool).await {
+        Ok(Some(block_header)) => {
+            tracing::info!("Latest block found: {:?}", block_header);
+            match block_header.timestamp {
+                Some(timestamp) => {
+                    tracing::info!("Block timestamp found: {}", timestamp);
+                    (
+                        StatusCode::OK,
+                        Json(GetLatestBlockResponseEnum::Success(LatestBlockResponse {
+                            latest_block_number: block_header.number,
+                            block_timestamp: timestamp,
+                        })),
+                    )
+                }
+                None => {
+                    tracing::error!("Block timestamp is missing");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(GetLatestBlockResponseEnum::Error(ErrorResponse {
+                            error: "Block timestamp is missing".to_string(),
+                        })),
+                    )
+                }
+            }
+        }
+        Ok(None) => {
+            tracing::info!("No block found");
+            (
+                StatusCode::NOT_FOUND,
+                Json(GetLatestBlockResponseEnum::Error(ErrorResponse {
+                    error: "No block found".to_string(),
+                })),
+            )
+        }
+        Err(e) => {
+            tracing::error!("Failed to fetch block: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(GetLatestBlockResponseEnum::Error(ErrorResponse {
+                    error: "An internal error occurred. Please try again later.".to_string(),
+                })),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::panic;
+
+    use crate::{handlers::fixtures::TestContext, types::GetLatestBlockResponseEnum};
+    use axum::{http::StatusCode, Json};
+
+    #[tokio::test]
+    async fn test_get_latest_block_not_found() {
+        let ctx = TestContext::new().await;
+
+        let (status, Json(response)) = ctx.get_latest_block().await;
+
+        let response = match response {
+            GetLatestBlockResponseEnum::Error(err_response) => err_response,
+            GetLatestBlockResponseEnum::Success(_) => panic!("Unexpected response status"),
+        };
+
+        println!("Status: {}", status);
+        println!("Response: {:?}", response);
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(response.error, "No block found");
+    }
+
+    #[tokio::test]
+    async fn test_get_latest_block_success() {
+        let ctx = TestContext::new().await;
+
+        // Create three blocks with different timestamps
+        ctx.create_block(12345, 1234567890_i64, 0).await;
+        ctx.create_block(12346, 1234567891_i64, 0).await;
+        let latest_block = 12347;
+        let latest_timestamp = 1234567892_i64;
+        ctx.create_block(latest_block, latest_timestamp, 0).await;
+
+        let (status, Json(response)) = ctx.get_latest_block().await;
+
+        let response = match response {
+            GetLatestBlockResponseEnum::Success(success_res) => success_res,
+            GetLatestBlockResponseEnum::Error(_) => panic!("Unexpected response status"),
+        };
+
+        println!("Status: {}", status);
+        println!("Response: {:?}", response);
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(response.latest_block_number, latest_block);
+        assert_eq!(response.block_timestamp, latest_timestamp);
+    }
+
+    #[tokio::test]
+    async fn test_get_latest_block_internal_error() {
+        let ctx = TestContext::new().await;
+
+        // Drop the blockheaders table to cause a database error
+        sqlx::query("DROP TABLE blockheaders")
+            .execute(&ctx.db_pool)
+            .await
+            .expect("Failed to drop table");
+
+        let (status, Json(response)) = ctx.get_latest_block().await;
+
+        let response = match response {
+            GetLatestBlockResponseEnum::Error(err_response) => err_response,
+            GetLatestBlockResponseEnum::Success(_) => panic!("Unexpected response status"),
+        };
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            response.error,
+            "An internal error occurred. Please try again later."
+        );
+    }
+}

--- a/crates/server/src/handlers/mod.rs
+++ b/crates/server/src/handlers/mod.rs
@@ -4,3 +4,4 @@ pub mod fixtures;
 pub mod get_pricing_data;
 pub mod health_check;
 pub mod job_status;
+pub mod latest_block;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -53,6 +53,10 @@ pub async fn create_app(pool: PgPool) -> Router {
             "/job_status/:job_id",
             get(handlers::job_status::get_job_status),
         )
+        .route(
+            "/latest_block",
+            get(handlers::latest_block::get_latest_block_number),
+        )
         .layer(CorsLayer::permissive());
     //.layer(cors_layer.clone());
 

--- a/crates/server/src/types.rs
+++ b/crates/server/src/types.rs
@@ -52,3 +52,16 @@ pub enum GetJobStatusResponseEnum {
     Success(JobResponse),
     Error(ErrorResponse),
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LatestBlockResponse {
+    pub latest_block_number: i64,
+    pub block_timestamp: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum GetLatestBlockResponseEnum {
+    Success(LatestBlockResponse),
+    Error(ErrorResponse),
+}


### PR DESCRIPTION
This PR introduces a new endpoint that returns the `number` and `timestamp` of the highest block stored in the DB.

#### Motivation

Users who deploy vaults will have a cron job available they can use to automate the state transition of the rounds.
The cron job will call the endpoint to check if all the blocks required for round settlement exist in the DB.

