### PR TITLE
Matt/group by 1h intervals

### DIFF
--- a/crates/server/src/handlers/job_status.rs
+++ b/crates/server/src/handlers/job_status.rs
@@ -116,7 +116,7 @@ mod tests {
         // Create a completed job with a sample result
         let sample_result = json!({
             "twap": 12345.67,
-            "volatility": 2345.89,
+            "max_returns": 2345.89,
             "reserve_price": 3456.78
         });
 

--- a/crates/server/src/pricing_data/max_returns.rs
+++ b/crates/server/src/pricing_data/max_returns.rs
@@ -128,24 +128,25 @@ fn add_twap_30d(df: DataFrame) -> Result<DataFrame> {
 /// * The grouping or aggregation operations fail.
 /// * The final collection of the lazy DataFrame fails.
 ///
-// Instead of grouping, just sort the data
 fn group_by_1h_intervals(df: DataFrame) -> Result<DataFrame> {
-    tracing::debug!("DataFrame shape before sorting: {:?}", df.shape());
+    tracing::debug!("DataFrame shape before grouping: {:?}", df.shape());
 
     let df = df
         .lazy()
-        .sort(
-            vec!["date"],
-            SortMultipleOptions {
-                descending: vec![false],
-                nulls_last: vec![true],
-                multithreaded: true,
-                maintain_order: false,
+        .group_by_dynamic(
+            col("date"),
+            [],
+            DynamicGroupOptions {
+                every: Duration::parse("1h"),
+                period: Duration::parse("1h"),
+                offset: Duration::parse("0"),
+                ..Default::default()
             },
         )
+        .agg([col("base_fee").mean()])
         .collect()?;
 
-    tracing::debug!("DataFrame shape after sorting: {:?}", df.shape());
+    tracing::debug!("DataFrame shape after grouping: {:?}", df.shape());
     tracing::debug!("DataFrame: {:?}", df);
 
     Ok(df)

--- a/crates/server/src/pricing_data/reserve_price.rs
+++ b/crates/server/src/pricing_data/reserve_price.rs
@@ -593,24 +593,25 @@ fn add_twap_7d(df: DataFrame) -> Result<DataFrame> {
 /// * The grouping or aggregation operations fail.
 /// * The final collection of the lazy `DataFrame` fails.
 ///
-// Instead of grouping, just sort the data
 fn group_by_1h_intervals(df: DataFrame) -> Result<DataFrame> {
-    tracing::debug!("DataFrame shape before sorting: {:?}", df.shape());
+    tracing::debug!("DataFrame shape before grouping: {:?}", df.shape());
 
     let df = df
         .lazy()
-        .sort(
-            vec!["date"],
-            SortMultipleOptions {
-                descending: vec![false],
-                nulls_last: vec![true],
-                multithreaded: true,
-                maintain_order: false,
+        .group_by_dynamic(
+            col("date"),
+            [],
+            DynamicGroupOptions {
+                every: Duration::parse("1h"),
+                period: Duration::parse("1h"),
+                offset: Duration::parse("0"),
+                ..Default::default()
             },
         )
+        .agg([col("base_fee").mean()])
         .collect()?;
 
-    tracing::debug!("DataFrame shape after sorting: {:?}", df.shape());
+    tracing::debug!("DataFrame shape after grouping: {:?}", df.shape());
     tracing::debug!("DataFrame: {:?}", df);
 
     Ok(df)


### PR DESCRIPTION
Implement 1hr grouping logic using this [implementation](https://github.com/OilerNetwork/pitchlake-pricing/blob/0423c7e0a1f736a6568e552d9e8cc320817f9055/src/main.rs#L648) as reference.